### PR TITLE
Return mapped synthesis data (ids) for a person

### DIFF
--- a/DataTier-APIs/Quarkus-APIs/pom.xml
+++ b/DataTier-APIs/Quarkus-APIs/pom.xml
@@ -10,10 +10,10 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <quarkus-plugin.version>2.2.3.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.8.0.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.2.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.8.0.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.release.version>2.5.3</maven.release.version>

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/apis/CrossmapDetailResource.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/apis/CrossmapDetailResource.java
@@ -8,7 +8,6 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/apis/PersonCrossmapResource.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/apis/PersonCrossmapResource.java
@@ -4,30 +4,27 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 import io.connectedhealth.idaas.defianz.audit.Audited;
-import io.connectedhealth.idaas.defianz.dtos.PersonIdentity;
+import io.connectedhealth.idaas.defianz.dtos.CrossmapPersonDetail;
 import io.connectedhealth.idaas.defianz.dtos.PersonIdentityIn;
-import io.connectedhealth.idaas.defianz.services.PersonIdentityService;
+import io.connectedhealth.idaas.defianz.services.CrossmapRetrieveService;
 import io.connectedhealth.idaas.defianz.exception.DefianzException;
 
-@Path("/person-identities")
+@Path("/person-crossmaps")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class PersonIdentityResource {
+public class PersonCrossmapResource {
     @Inject
-    PersonIdentityService service;
+    CrossmapRetrieveService service;
 
     @Audited
     @POST
-    public PersonIdentity identifyPerson(PersonIdentityIn personInfo) throws DefianzException {
-        return service.identify(personInfo);
+    public List<CrossmapPersonDetail> identifyPerson(PersonIdentityIn personInfo) throws DefianzException {
+        return service.retrieveMapping(personInfo);
     }
 }

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/datasynthesis/IDataSynthesisService.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/datasynthesis/IDataSynthesisService.java
@@ -1,0 +1,19 @@
+package io.connectedhealth.idaas.defianz.datasynthesis;
+
+import java.util.List;
+
+import javax.json.JsonObject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+
+@Path("/api")
+@RegisterRestClient
+public interface IDataSynthesisService {
+    @GET
+    @Path("/{resourceName}")
+    List<JsonObject> randomOne(@PathParam String resourceName, @QueryParam("count") int count);
+}

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/dtos/CrossmapPersonDetail.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/dtos/CrossmapPersonDetail.java
@@ -1,0 +1,22 @@
+package io.connectedhealth.idaas.defianz.dtos;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+
+public class CrossmapPersonDetail {
+    public int dataAttributeId;
+    public long dataValueId;
+    public String crossmapField;
+
+    public CrossmapPersonDetail(){}
+
+    public CrossmapPersonDetail(int dataAttributeId, long dataValueId, String crossmapField) {
+        this.dataAttributeId = dataAttributeId;
+        this.dataValueId = dataValueId;
+        this.crossmapField = crossmapField;
+    }
+
+    public String toString()
+    {
+        return ReflectionToStringBuilder.toString(this);
+    }
+}

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/models/CrossmapDetailEntity.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/models/CrossmapDetailEntity.java
@@ -13,7 +13,6 @@ import javax.persistence.Table;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Timestamp;
-import java.util.List;
 
 @Entity
 @Table(name = "crossmaps_dtl")

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/models/CrossmapPersonDetailEntity.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/models/CrossmapPersonDetailEntity.java
@@ -1,0 +1,112 @@
+package io.connectedhealth.idaas.defianz.models;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "crossmaps_person_dtl")
+public class CrossmapPersonDetailEntity extends io.quarkus.hibernate.orm.panache.PanacheEntityBase {
+    private long crossmapPersonDetailId;
+    private long dataValueId;
+    private Timestamp createdDate;
+    private PersonIdentityEntity personIdentity;
+    private CrossmapDetailEntity crossmapDetail;
+    private RefDataStatusEntity status;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "crossmapspersondtlid", nullable = false)
+    public long getCrossmapsPersonDetailId() {
+        return crossmapPersonDetailId;
+    }
+
+    public void setCrossmapsPersonDetailId(long crossmapPersonDetailId) {
+        this.crossmapPersonDetailId = crossmapPersonDetailId;
+    }
+
+
+    @Basic
+    @Column(name = "keydatavalueid", nullable = false)
+    public long getDataValueId() {
+        return dataValueId;
+    }
+
+    public void setDataValueId(long dataValueId) {
+        this.dataValueId = dataValueId;
+    }
+
+    @Basic
+    @CreationTimestamp
+    @Column(name = "createddate", nullable = true)
+    public Timestamp getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Timestamp createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    @Override
+    public int hashCode() {
+		return java.util.Objects.hash(crossmapPersonDetailId, dataValueId, personIdentity,
+					createdDate, crossmapDetail, status);
+	}
+
+    @Override
+    public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null)
+			return false;
+		if (getClass() != o.getClass())
+			return false;
+		CrossmapPersonDetailEntity other = (CrossmapPersonDetailEntity) o;
+		return java.util.Objects.equals(crossmapPersonDetailId, other.crossmapPersonDetailId) &&
+			java.util.Objects.equals(dataValueId, other.dataValueId) &&
+			java.util.Objects.equals(createdDate, other.createdDate) &&
+			java.util.Objects.equals(personIdentity, other.personIdentity) &&
+            java.util.Objects.equals(crossmapDetail, other.crossmapDetail) && 
+			java.util.Objects.equals(status, other.status);
+	}
+
+    @ManyToOne
+    @JoinColumn(name = "statusid", referencedColumnName = "statusid")
+    public RefDataStatusEntity getStatus() {
+        return status;
+    }
+
+    public void setStatus(RefDataStatusEntity status) {
+        this.status = status;
+    }
+
+    @ManyToOne
+    @JoinColumn(name = "personidentityid", referencedColumnName = "personidentityid")
+    public PersonIdentityEntity getPersonIdentity() {
+        return personIdentity;
+    }
+
+    public void setPersonIdentity(PersonIdentityEntity personIdentity) {
+        this.personIdentity = personIdentity;
+    }
+
+    @ManyToOne
+    @JoinColumn(name = "crossmapsdtlid", referencedColumnName = "crossmapdtlid")
+    public CrossmapDetailEntity getCrossmapDetail() {
+        return crossmapDetail;
+    }
+
+    public void setCrossmapDetail(CrossmapDetailEntity crossmapDetail) {
+        this.crossmapDetail = crossmapDetail;
+    }
+}

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/models/DataAttributeEntity.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/models/DataAttributeEntity.java
@@ -22,6 +22,7 @@ public class DataAttributeEntity extends io.quarkus.hibernate.orm.panache.Panach
     private Timestamp createdDate;
     private RefDataStatusEntity status;
     private String createdUser;
+    private String endpoint;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,6 +53,16 @@ public class DataAttributeEntity extends io.quarkus.hibernate.orm.panache.Panach
 
     public void setCreatedUser(String user) {
         this.createdUser = user;
+    }
+
+    @Basic
+    @Column(name = "endpoint")
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
     }
 
     @Basic

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/services/CrossmapRetrieveService.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/services/CrossmapRetrieveService.java
@@ -1,0 +1,65 @@
+package io.connectedhealth.idaas.defianz.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.transaction.Transactional;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import io.connectedhealth.idaas.defianz.datasynthesis.IDataSynthesisService;
+import io.connectedhealth.idaas.defianz.dtos.CrossmapPersonDetail;
+import io.connectedhealth.idaas.defianz.dtos.PersonIdentityIn;
+import io.connectedhealth.idaas.defianz.models.CrossmapDetailEntity;
+import io.connectedhealth.idaas.defianz.models.CrossmapEntity;
+import io.connectedhealth.idaas.defianz.models.CrossmapPersonDetailEntity;
+import io.connectedhealth.idaas.defianz.models.PersonIdentityEntity;
+
+@ApplicationScoped
+public class CrossmapRetrieveService {
+    @Inject
+    PersonIdentityService personService;
+
+    @Inject
+    @RestClient
+    IDataSynthesisService dataService;
+    
+    public List<CrossmapPersonDetail> retrieveMapping(PersonIdentityIn personInfo){
+        PersonIdentityEntity personIdentity = personService.identify(personInfo);
+        List<CrossmapPersonDetailEntity> results = CrossmapPersonDetailEntity.find("personIdentity = ?1", personIdentity).list();
+        if(results.isEmpty()) {
+            results = createCrossmapPersonDetails(personIdentity);
+        }
+        return results.stream().map(e -> mapEntityToDTO(e)).collect(Collectors.toList());
+    }
+
+    @Transactional
+    protected List<CrossmapPersonDetailEntity> createCrossmapPersonDetails(PersonIdentityEntity person) {
+        CrossmapEntity crossMap = CrossmapEntity.find("application = ?1 AND organization = ?2", person.getApplication(), person.getOrganization()).firstResult();
+        List<CrossmapDetailEntity> cmDetails = CrossmapDetailEntity.find("crossmapid = ?1", crossMap.getCrossmapId()).list();
+        List<CrossmapPersonDetailEntity> results = new ArrayList<CrossmapPersonDetailEntity>();
+        for(CrossmapDetailEntity cm : cmDetails) {
+            JsonObject data = dataService.randomOne(cm.getDataAttribute().getEndpoint(), 1).get(0);
+            CrossmapPersonDetailEntity cpde = new CrossmapPersonDetailEntity();
+            cpde.setCrossmapDetail(cm);
+            cpde.setPersonIdentity(person);
+            cpde.setDataValueId(data.getInt("id"));
+            cpde.persist();
+            results.add(cpde);
+        }
+        return results;
+    }
+
+
+    protected CrossmapPersonDetail mapEntityToDTO(CrossmapPersonDetailEntity e) {
+        CrossmapPersonDetail dto = new CrossmapPersonDetail();
+        dto.crossmapField = e.getCrossmapDetail().getCrossmapField();
+        dto.dataAttributeId = e.getCrossmapDetail().getDataAttribute().getDataAttributeId();
+        dto.dataValueId = e.getDataValueId();
+        return dto;
+    }
+}

--- a/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/services/PersonIdentityService.java
+++ b/DataTier-APIs/Quarkus-APIs/src/main/java/io/connectedhealth/idaas/defianz/services/PersonIdentityService.java
@@ -6,7 +6,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
 import org.apache.commons.codec.digest.DigestUtils;
 
-import io.connectedhealth.idaas.defianz.dtos.PersonIdentity;
 import io.connectedhealth.idaas.defianz.dtos.PersonIdentityIn;
 import io.connectedhealth.idaas.defianz.models.PersonIdentityEntity;
 
@@ -16,7 +15,7 @@ import io.quarkus.hibernate.orm.panache.PanacheQuery;
 @ApplicationScoped
 public class PersonIdentityService {
     @Transactional
-    public PersonIdentity identify(PersonIdentityIn personInfo) {        
+    public PersonIdentityEntity identify(PersonIdentityIn personInfo) {
         StringBuilder dataString = new StringBuilder();
         Map<String, Object> data = personInfo.identifiers;
         data.entrySet()
@@ -24,7 +23,6 @@ public class PersonIdentityService {
             .sorted(Map.Entry.<String, Object>comparingByKey())
             .forEach(dataString::append);
 
-        
         String sha = DigestUtils.sha256Hex(dataString.toString());
 
         PersonIdentityEntity entity = new PersonIdentityEntity();
@@ -36,19 +34,11 @@ public class PersonIdentityService {
             entity.persistAndFlush();
             result = entity;
         }
-        return mapEntityToDTO(result);
+        return result;
     }
 
     private PanacheQuery buildQuery(PersonIdentityEntity e){
         String query = "application = ?1 and organization = ?2 and sha256 = ?3";
         return PersonIdentityEntity.find(query, e.getApplication(), e.getOrganization(), e.getSha256());
-    }
-
-    protected PersonIdentity mapEntityToDTO(PersonIdentityEntity e) {
-        PersonIdentity person = new PersonIdentity();
-        person.application = e.getApplication();
-        person.organization = e.getOrganization();
-        person.personIdentityId = e.getPersonIdentityId();
-        return person;
     }     
 }

--- a/DataTier-APIs/Quarkus-APIs/src/main/resources/application.properties
+++ b/DataTier-APIs/Quarkus-APIs/src/main/resources/application.properties
@@ -13,7 +13,7 @@ quarkus.hibernate-orm.database.default-catalog=
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.log.sql=true
 # Liquibase
-quarkus.liquibase.migrate-at-start=true
+quarkus.liquibase.migrate-at-start=false
 quarkus.liquibase.change-log=db/changelog/changeLog-master.yaml
 # Always include the swagger-api in the application
 quarkus.swagger-ui.always-include=true
@@ -29,6 +29,9 @@ quarkus.http.non-application-root-path=/
 defianz.audit=false
 io.connectedhealth.idaas.defianz.audit.IDaasKicService/mp-rest/url=${AUDITING_URL:http://localhost:9970}
 io.connectedhealth.idaas.defianz.audit.IDaasKicService/mp-rest/scope=javax.inject.Singleton
+# rest client connecting to datasynthesis
+io.connectedhealth.idaas.defianz.datasynthesis.IDataSynthesisService/mp-rest/url=${DATASYNTHESIS_URL:http://localhost:8999}
+io.connectedhealth.idaas.defianz.datasynthesis.IDataSynthesisService/mp-rest/scope=javax.inject.Singleton
 # Testing
 %test.quarkus.datasource.db-kind=h2
 %test.quarkus.datasource.jdbc.driver=org.h2.Driver

--- a/DataTier-APIs/Quarkus-APIs/src/test/java/io/connectedhealth/idaas/defianz/services/PersonIdentityServiceTest.java
+++ b/DataTier-APIs/Quarkus-APIs/src/test/java/io/connectedhealth/idaas/defianz/services/PersonIdentityServiceTest.java
@@ -4,9 +4,8 @@ import java.util.HashMap;
 
 import javax.inject.Inject;
 
-import io.connectedhealth.idaas.defianz.dtos.PersonIdentity;
 import io.connectedhealth.idaas.defianz.dtos.PersonIdentityIn;
-
+import io.connectedhealth.idaas.defianz.models.PersonIdentityEntity;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,11 +32,11 @@ public class PersonIdentityServiceTest {
     @Test
     public void testIdentifyPerson() {
         PersonIdentityIn personIn1 = prepareInput();
-        PersonIdentity out1 = service.identify(personIn1);
-        Assertions.assertTrue(out1.personIdentityId > 0);
+        PersonIdentityEntity out1 = service.identify(personIn1);
+        Assertions.assertTrue(out1.getPersonIdentityId() > 0);
 
         PersonIdentityIn personIn2 = prepareInput();
-        PersonIdentity out2 = service.identify(personIn2);
-        Assertions.assertEquals(out1.personIdentityId, out2.personIdentityId);
+        PersonIdentityEntity out2 = service.identify(personIn2);
+        Assertions.assertEquals(out1.getPersonIdentityId(), out2.getPersonIdentityId());
     }
 }


### PR DESCRIPTION
After cross-map is defined, we now can use endpoint `/person-crossmaps` to post a person's identities and get back a list of mapped synthesis data (ids).

sample output
```
[
  {
    "crossmapField": "PV1.7.1",
    "dataAttributeId": 15,
    "dataValueId": 2701
  },
  {
    "crossmapField": "PV1.7.2",
    "dataAttributeId": 1,
    "dataValueId": 15
  },
  {
    "crossmapField": "PV1.7.3",
    "dataAttributeId": 20,
    "dataValueId": 2982
  }
]
```